### PR TITLE
moved optional parameter to the end

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -140,57 +140,6 @@ jobs:
           name: "unit-${{ matrix.php }}.coverage"
           path: "tests/support/coverage.xml"
 
-  qodana-analysis:
-    permissions:
-      contents: read
-
-    name: "Qodana Analysis"
-    runs-on: "ubuntu-22.04"
-    needs:
-      - "unit-tests"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v3"
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
-          fetch-depth: 0  # a full history is required for pull request analysis
-
-      - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.2
-        env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
-        with:
-          args: --baseline,qodana.sarif.json
-
-  upload-coverage:
-    permissions:
-      contents: read
-
-    name: "Upload coverage"
-    runs-on: "ubuntu-22.04"
-    needs:
-      - "unit-tests"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Display structure of downloaded files"
-        run: |
-          mkdir -p reports
-
-      - name: "Download coverage files"
-        uses: "actions/download-artifact@v4"
-        with:
-          path: "reports"
-
-      - name: "Display structure of downloaded files"
-        run: ls -R
-        working-directory: reports
-
 #      - name: "Upload to Codacy"
 #        run: |
 #          bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
@@ -214,10 +163,3 @@ jobs:
 #          fail_ci_if_error: true
 #          verbose: true
 #
-      - name: "Upload to Qodana"
-        run: |
-          docker run \
-            -v $(pwd):/data/project/ \
-            -v ./reports/:/data/coverage \
-            -e QODANA_TOKEN="${{ secrets.QODANA_TOKEN }}" \
-            jetbrains/qodana-php

--- a/files/parser.php
+++ b/files/parser.php
@@ -2747,7 +2747,7 @@ static const struct {
             case 70:
 #line 462 "parser.php.lemon"
                 {
-                    phvolt_ret_cache_statement($this->output, $this->yystack[$this->yyidx + -5]->minor, null, $this->yystack[$this->yyidx + -3]->minor, $this->status->getState());
+                    phvolt_ret_cache_statement($this->output, $this->yystack[$this->yyidx + -5]->minor, $this->yystack[$this->yyidx + -3]->minor, $this->status->getState());
                     $this->yy_destructor(1, $this->yystack[$this->yyidx + -7]->minor);
                     $this->yy_destructor(66, $this->yystack[$this->yyidx + -6]->minor);
                     $this->yy_destructor(32, $this->yystack[$this->yyidx + -4]->minor);
@@ -2760,7 +2760,7 @@ static const struct {
             case 71:
 #line 466 "parser.php.lemon"
                 {
-                    phvolt_ret_cache_statement($this->output, $this->yystack[$this->yyidx + -6]->minor, $this->yystack[$this->yyidx + -5]->minor, $this->yystack[$this->yyidx + -3]->minor, $this->status->getState());
+                    phvolt_ret_cache_statement($this->output, $this->yystack[$this->yyidx + -6]->minor, $this->yystack[$this->yyidx + -3]->minor, $this->status->getState(), $this->yystack[$this->yyidx + -5]->minor);
                     $this->yy_destructor(1, $this->yystack[$this->yyidx + -8]->minor);
                     $this->yy_destructor(66, $this->yystack[$this->yyidx + -7]->minor);
                     $this->yy_destructor(32, $this->yystack[$this->yyidx + -4]->minor);
@@ -3796,7 +3796,7 @@ function phvolt_ret_block_statement(array &$ret, Token $name, ?array $block_stat
     $ret['line'] = $state->getActiveLine();
 }
 
-function phvolt_ret_cache_statement(array &$ret, mixed $expr, mixed $lifetime = null, mixed $block_statements, State $state): void
+function phvolt_ret_cache_statement(array &$ret, mixed $expr, mixed $block_statements, State $state, mixed $lifetime = null): void
 {
     $ret = [];
     $ret['type'] = Compiler::PHVOLT_T_CACHE;


### PR DESCRIPTION
Move the `$lifetime` parameter to the end of the method call to avoid deprecation warnings.